### PR TITLE
Provide option to process moduleroot_init templates during convert/update

### DIFF
--- a/lib/pdk/cli/convert.rb
+++ b/lib/pdk/cli/convert.rb
@@ -9,6 +9,7 @@ module PDK::CLI
     PDK::CLI.template_url_option(self)
     PDK::CLI.skip_interview_option(self)
     PDK::CLI.full_interview_option(self)
+    flag nil, :init, _('Also process templates only added during module creation.')
     flag nil, :noop, _('Do not convert the module, just output what would be done.')
     flag nil, :force, _('Convert the module automatically, with no prompts.')
 

--- a/lib/pdk/cli/update.rb
+++ b/lib/pdk/cli/update.rb
@@ -7,6 +7,7 @@ module PDK::CLI
     usage _('update [options]')
     summary _('Update a module that has been created by or converted for use by PDK.')
 
+    flag nil, :init, _('Also process templates only added during module creation.')
     flag nil, :noop, _('Do not update the module, just output what would be done.')
     flag nil, :force, _('Update the module automatically, with no prompts.')
 

--- a/lib/pdk/module/convert.rb
+++ b/lib/pdk/module/convert.rb
@@ -68,7 +68,7 @@ module PDK
       def stage_changes!
         metadata_path = 'metadata.json'
 
-        PDK::Module::TemplateDir.new(template_url, nil, false) do |templates|
+        PDK::Module::TemplateDir.new(template_url, nil, options[:init]) do |templates|
           new_metadata = update_metadata(metadata_path, templates.metadata)
           templates.module_metadata = new_metadata.data unless new_metadata.nil?
 


### PR DESCRIPTION
PDK moduleroot_init templates are only added to a module during creation (pdk new). There is currently no mechanism to get these templates added to an existing module. This commit adds an init flag that forces the moduleroot_init templates to be processed during convert/update.